### PR TITLE
Add values to enum entries

### DIFF
--- a/cwrap/backend/cw_ast.py
+++ b/cwrap/backend/cw_ast.py
@@ -511,6 +511,19 @@ class Expr(stmt):
         assert_expr(value, 'value')
         self.value = value
 
+class EnumValue(stmt):
+    """ An expression node. Inherits stmt.
+
+    value : an expr node.
+
+    """
+    def init(self, name, value, islast=0):
+        assert_int(value, 'value')
+        self.value = value
+        assert_expr(name, 'name')
+        self.name = name.id
+        self.islast = islast
+
 
 class Pass(stmt):
     """ The pass statement. Inherits stmt. Singleton.

--- a/cwrap/backend/renderer.py
+++ b/cwrap/backend/renderer.py
@@ -612,6 +612,14 @@ class ASTRenderer(object):
         self.code.dedent()
 
         self.code.newline()
+
+    def visit_EnumValue(self, enum):
+        name = enum.name
+        value = enum.value
+        head = '%s = %s' % (name, value)
+        self.code.write_i(head)
+        self.code.newline()
+
     
     def visit_Property(self, prop):
         name = prop.name

--- a/cwrap/frontends/clang/ast_transforms.py
+++ b/cwrap/frontends/clang/ast_transforms.py
@@ -394,9 +394,11 @@ class CAstTransformer(object):
         name = enum.name
         return cw_ast.TypeName(cw_ast.Name(name, cw_ast.Param))
 
-    def translate_EnumValue(self, value):
-        name = value.name
-        return cw_ast.Expr(cw_ast.Name(name, cw_ast.Param))
+    def translate_EnumValue(self, enum):
+        name = enum.name
+        value = enum.value
+        return cw_ast.EnumValue(cw_ast.Name(name, cw_ast.Param),
+                                value)
 
     def translate_Struct(self, struct):
         name = struct.name


### PR DESCRIPTION
Hello,

In our C code we give values to our enum entries, I modified cwrap so that it takes those values.
This code break some tests but I think it's not a big deal, it just add values to enum where there wasn't.

eg.:

enum toto {
    enum1,
    enum2,
    enum3
};

will give 

ctypedef enum toto:
    enum1 = 0
    enum2 = 1
    enum3 = 2

Thanks for all your work,

XL.
